### PR TITLE
Update connecting.md

### DIFF
--- a/articles/connecting.md
+++ b/articles/connecting.md
@@ -96,6 +96,11 @@ threads can wait for a connection.
 The maximum wait time in milliseconds that a thread may wait for a connection to become available.
 A value of 0 means that it will not wait. A negative value means to wait indefinitely.
 
+**NB!** Mongo-javadriver newer than *2.11*, a negative value is not anymore accepted  and 
+it will raise *IllegalArgumentException*:
+
+`IllegalArgumentException Minimum value is 0  com.mongodb.MongoClientOptions$Builder.maxWaitTime (MongoClientOptions.java:115)`
+
 
 #### :connect-timeout (default: 0)
 


### PR DESCRIPTION
Changed documentation for :max-wait-time and fixed fact that newer java-driver than 2.11, negative values are not allowed anymore.
