### PR TITLE
Add missing curly braces in upsert example

### DIFF
--- a/articles/getting_started.md
+++ b/articles/getting_started.md
@@ -629,7 +629,7 @@ upsert with Monger, use `monger.collection/update` function with
   (:require [monger.collection :as mc]))
 
 ;; updates score for player "sam" if it exists; creates a new document otherwise
-(mc/update db "scores" {:player "sam"} {:score 1088} :upsert true)
+(mc/update db "scores" {:player "sam"} {:score 1088} {:upsert true})
 ```
 
 Note that upsert only inserts one document. Learn more about upserts


### PR DESCRIPTION
Going through some of the examples from 'Getting started', I noticed

``` clojure
(let [conn (mg/connect)
      db   (mg/get-db conn "monger-test")
      coll "documents"]
  ;; insert a few documents
  (mc/update db "scores" {:player "sam"} {:score 1088} :upsert true))
```

raises the compile error,

```
ArityException Wrong number of args (6) passed to: collection/update  clojure.lang.AFn.throwArity (AFn.java:429)
```

And can confirm that it works when it's replaced with the following (with the last arg as a hash map)

``` clojure
(mc/update db "scores" {:player "sam"} {:score 1088} {:upsert true})
```

```
=> #<WriteResult { "serverUsed" : "127.0.0.1:27017" , "ok" : 1 , "n" : 1 , "updatedExisting" : false , "upserted" : { "$oid" : "540d71420f2b1e26b47bce34"}}>
```

Thanks for reviewing.
