### PR TITLE
Updating getting_started.md: how to disable the logging

### DIFF
--- a/articles/getting_started.md
+++ b/articles/getting_started.md
@@ -90,6 +90,18 @@ And then the dependency:
 </dependency>
 ```
 
+### Caveats
+
+From the `3.0.0-beta` MongoDB Java driver, all logging was switched to 
+SLF4J 
+([reference](https://groups.google.com/d/msg/mongodb-user/_t5rHlaxYxI/aNdlMVIrcR0J)).
+To get ride of the verbose logging from the driver, add the following
+artifact to your dependencies:
+
+``` clojure
+[org.slf4j/slf4j-nop "1.7.12"]
+```
+
 ## Connecting to MongoDB
 
 Before using Monger, you need to connect to MongoDB and choose a database to


### PR DESCRIPTION
An instruction to get ride of logging messages from the driver was added
to `getting_started.md`. A reference to the solution's source was also given.